### PR TITLE
Add preference for increased touch sensitivity (glove mode)

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -3237,6 +3237,10 @@
     <string name="auto_rotate_summary_no_permission">Camera access is required for Face Detection. Tap to manage permissions for Device Personalization Services</string>
     <!-- auto_rotate settings screen, text for the camera permission button [CHAR LIMIT=NONE]-->
     <string name="auto_rotate_manage_permission_button">Manage permissions</string>
+    <!-- Display settings screen, increased touch sensitivity settings title [CHAR LIMIT=30] -->
+    <string name="touch_sensitivity_title">Increase sampling rate</string>
+    <!-- Display settings screen, increased touch sensitivity settings summary [CHAR LIMIT=NONE] -->
+    <string name="touch_sensitivity_summary">Improves touch increasing sampling rate to max supported</string>
 
     <!-- Night display screen, setting option name to enable night display (renamed "Night Light" with title caps). [CHAR LIMIT=30] -->
     <string name="night_display_title">Night Light</string>

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -160,6 +160,12 @@
             settings:controller="com.android.settings.display.PeakRefreshRatePreferenceController"/>
 
         <SwitchPreference
+            android:key="touch_sensitivity"
+            android:title="@string/touch_sensitivity_title"
+            android:summary="@string/touch_sensitivity_summary"
+            settings:controller="com.android.settings.display.TouchSensitivityPreferenceController" />
+
+        <SwitchPreference
             android:key="show_operator_name"
             android:title="@string/show_operator_name_title"
             android:summary="@string/show_operator_name_summary"/>

--- a/src/com/android/settings/display/TouchSensitivityPreferenceController.java
+++ b/src/com/android/settings/display/TouchSensitivityPreferenceController.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2021 The Proton AOSP Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.display;
+
+import android.content.Context;
+import android.os.SystemProperties;
+import android.provider.Settings;
+
+import com.android.settings.core.TogglePreferenceController;
+import com.android.settings.R;
+
+public class TouchSensitivityPreferenceController extends TogglePreferenceController {
+
+    // Settings can only set the debug.* property, so we need to persist it
+    // in system settings. Match the stock setting name for backup compatibility.
+    private static final String SETTINGS_KEY = "touch_sensitivity_enabled";
+    private static final String PROP_NAME = "debug.touch_sensitivity_mode";
+
+    public TouchSensitivityPreferenceController(Context context, String preferenceKey) {
+        super(context, preferenceKey);
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return mContext.getResources().getBoolean(com.android.internal.R.bool.config_supportGloveMode)
+            ? AVAILABLE
+            : UNSUPPORTED_ON_DEVICE;
+    }
+
+    @Override
+    public boolean setChecked(boolean value) {
+        Settings.Secure.putInt(mContext.getContentResolver(), SETTINGS_KEY, value ? 1 : 0);
+        SystemProperties.set(PROP_NAME, value ? "1" : "0");
+        return true;
+    }
+
+    @Override
+    public boolean isChecked() {
+        // debug prop isn't persistent
+        return Settings.Secure.getInt(mContext.getContentResolver(), SETTINGS_KEY, 0) == 1;
+    }
+
+    @Override
+    public int getSliceHighlightMenuRes() {
+        return R.string.menu_key_display;
+    }
+}


### PR DESCRIPTION
This preference controls the glove mode feature on Pixel devices for increased touch sensitivity without requiring a custom HAL or other device-side code. This is done by using the debug.touch_sensitivity_mode system property, which Settings has permission to change. The user-visible value is persisted in Settings.Secure, while the property is persisted in persist.vendor.touch_sensitivity_mode.

Requires frameworks/base commit: "Add a config to state whether a device supports increased touch sensitivity."
Requires device/google/* commit: "Express support for increased touch sensitivity."

Closes: #1

Change-Id: I86af721fde33226d314d8a44525f310828299a72